### PR TITLE
Use the correct `libquery_engine` name under Darwin

### DIFF
--- a/tests.nix
+++ b/tests.nix
@@ -14,6 +14,12 @@ let
       libquery-engine-hash = "sha256-oalG9QKuxURtdgs5DgJZZtyWMz3ZpywHlov+d1ct2vA=";
       schema-engine-hash = "sha256-5bp8iiq6kc9c37G8dNKVHKWJHvaxFaetR4DOR/0/eWs=";
     };
+    aarch64-darwin = {
+      prisma-fmt-hash = "sha256-UPig7U2zXOccalIUE0j07xJdmqAUJ7cpXFTo+2Gbsc8=";
+      query-engine-hash = "sha256-ihP1BEAvXQ+5XXHEXCYAVTnuETpfxmdtsIGRTljKtS0=";
+      libquery-engine-hash = "sha256-4T63O+OyoEIJ0TLKoOoil06whd+41QxiXXg+0cgpX/8=";
+      schema-engine-hash = "sha256-+O4IelHbZt4X+6UWol8TpL+BBDTS5JT+0hQR7ELVmZc=";
+    };
   };
   test-npm =
     let

--- a/tests.nix
+++ b/tests.nix
@@ -27,7 +27,7 @@ let
         echo "testing npm"
         ${prisma.shellHook}
         cd npm
-        npm ci
+        ${nixpkgs.nodejs}/bin/npm ci
         ./node_modules/.bin/prisma generate
       '';
     };
@@ -43,7 +43,7 @@ let
         echo "testing pnpm"
         ${prisma.shellHook}
         cd pnpm
-        pnpm install
+        ${nixpkgs.pnpm}/bin/pnpm install
         ./node_modules/.bin/prisma generate
       '';
     };


### PR DESCRIPTION
Tried to use this and found that the object name for Prisma's `libquery_engine` for Darwin is different from the Linux name, as well as the target name used in the URL. Fixed that and seems to work now.

Also added a darwin-arm64 case for the test scripts, and updated the test scripts to use npm & pnpm from nixpkgs, rather than relying on them to be in the user's environment.