### PR TITLE
Allow using `mkShell`'s `env` param to load the environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.direnv

--- a/prisma.nix
+++ b/prisma.nix
@@ -21,7 +21,9 @@ rec {
     let
       # polyfill: the function in nixpkgs is implemented on Dec 6, 2024. replace this with one from pkgs.lib after 24.11 reaches EOL.
       concatMapAttrsStringSep =
-        let inherit (nixpkgs) lib; in
+        let
+          inherit (nixpkgs) lib;
+        in
         sep: f: attrs:
         lib.concatStringsSep sep (lib.attrValues (lib.mapAttrs f attrs));
 
@@ -104,7 +106,8 @@ rec {
       ) files;
       unzipCommands = builtins.map (file: "gunzip -c ${file.file} > $out/${file.path}") downloadedFiles;
 
-      mkEnv = package:
+      mkEnv =
+        package:
         builtins.listToAttrs (
           builtins.map (file: {
             name = file.variable;
@@ -127,10 +130,8 @@ rec {
         # Type
         toExportStyle :: Attrset<String> -> String
       */
-      toExportStyle = attrset:
-        concatMapAttrsStringSep "\n"
-        (name: value: "export ${name}=${value}")
-        attrset;
+      toExportStyle =
+        attrset: concatMapAttrsStringSep "\n" (name: value: "export ${name}=${value}") attrset;
     in
     rec {
       package = nixpkgs.stdenv.mkDerivation {

--- a/prisma.nix
+++ b/prisma.nix
@@ -126,6 +126,7 @@ rec {
           export foo=bar
           export baz=abc
         ''
+        ```
 
         # Type
         toExportStyle :: Attrset<String> -> String

--- a/prisma.nix
+++ b/prisma.nix
@@ -116,15 +116,15 @@ rec {
         );
       /**
         This function converts attrset to bash export style.
-        may or may not contain leading or trailing \n. do not assume their existence.
+        return value contains leading and trailing newlines.
 
         # Example
         ```nix
         toExportStyle { foo = "bar"; baz = "abc"; }
         =>
         ''
-          export foo=bar
-          export baz=abc
+          export foo="bar"
+          export baz="abc"
         ''
         ```
 
@@ -132,7 +132,7 @@ rec {
         toExportStyle :: Attrset<String> -> String
       */
       toExportStyle =
-        attrset: concatMapAttrsStringSep "\n" (name: value: "export ${name}=${value}") attrset;
+        attrset: "\n" + (concatMapAttrsStringSep "\n" (name: value: "export ${name}=\"${value}\"") attrset) + "\n";
     in
     rec {
       package = nixpkgs.stdenv.mkDerivation {

--- a/readme.md
+++ b/readme.md
@@ -43,9 +43,9 @@ With nix-prisma-utils it's the other way around. You can simply install prisma t
     in
     {
       devShells.x86_64-linux.default = nixpkgs.mkShell {
-        shellHook = prisma.shellHook;
-        # you can also use `env` instead of shellHook.
-        # env = prisma.env;
+        env = prisma.env;
+        # or, you can use `shellHook` instead of `env` to load the same environment variables.
+        # shellHook = prisma.shellHook;
       };
     };
 }
@@ -75,9 +75,9 @@ With nix-prisma-utils it's the other way around. You can simply install prisma t
     in
     {
       devShells.x86_64-linux.default = nixpkgs.mkShell {
-        shellHook = prisma.shellHook;
-        # you can also use `env` instead of shellHook.
-        # env = prisma.env;
+        env = prisma.env;
+        # or, you can use `shellHook` instead of `env` to load the same environment variables.
+        # shellHook = prisma.shellHook;
       };
     };
 }
@@ -108,9 +108,9 @@ With nix-prisma-utils it's the other way around. You can simply install prisma t
     in
     {
       devShells.x86_64-linux.default = nixpkgs.mkShell {
-        shellHook = prisma.shellHook;
-        # you can also use `env` instead of shellHook.
-        # env = prisma.env;
+        env = prisma.env;
+        # or, you can use `shellHook` instead of `env` to load the same environment variables.
+        # shellHook = prisma.shellHook;
       };
     };
 }

--- a/readme.md
+++ b/readme.md
@@ -107,7 +107,11 @@ With nix-prisma-utils it's the other way around. You can simply install prisma t
           # NOTE: does not work with bun.lockb!
     in
     {
-      devShells.x86_64-linux.default = nixpkgs.mkShell { shellHook = prisma.shellHook; };
+      devShells.x86_64-linux.default = nixpkgs.mkShell {
+        shellHook = prisma.shellHook;
+        # you can also use `env` instead of shellHook.
+        # env = prisma.env;
+      };
     };
 }
 ```

--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,11 @@ With nix-prisma-utils it's the other way around. You can simply install prisma t
           ./package-lock.json; # <--- path to our package-lock.json file that contains the version of prisma-engines
     in
     {
-      devShells.x86_64-linux.default = nixpkgs.mkShell { shellHook = prisma.shellHook; };
+      devShells.x86_64-linux.default = nixpkgs.mkShell {
+        shellHook = prisma.shellHook;
+        # you can also use `env` instead of shellHook.
+        # env = prisma.env;
+      };
     };
 }
 
@@ -70,7 +74,11 @@ With nix-prisma-utils it's the other way around. You can simply install prisma t
           ./pnpm-lock.yaml; # <--- path to our pnpm-lock.yaml file that contains the version of prisma-engines
     in
     {
-      devShells.x86_64-linux.default = nixpkgs.mkShell { shellHook = prisma.shellHook; };
+      devShells.x86_64-linux.default = nixpkgs.mkShell {
+        shellHook = prisma.shellHook;
+        # you can also use `env` instead of shellHook.
+        # env = prisma.env;
+      };
     };
 }
 


### PR DESCRIPTION
Example:

```nix
let
  prisma = (prisma-utils.lib.prisma-factory {
    # ...
  }).fromNpmLock ./package-lock.json;
in
pkgs.mkShell {
  env = prisma.env;
  # inherit (prisma) env; # .. same thing with syntax sugar
}
```

- [x] is it backward compatible?
- [x] did the tests pass?
- [x] formatted using nixfmt-rfc-style (command `nixfmt`)

---