### PR TITLE
Support `bun.lock`.

### DIFF
--- a/bun/.gitignore
+++ b/bun/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/bun/bun.lock
+++ b/bun/bun.lock
@@ -1,0 +1,35 @@
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "bun",
+      "dependencies": {
+        "@prisma/client": "5.1.1",
+      },
+      "devDependencies": {
+        "prisma": "^6.3.0",
+      },
+    },
+  },
+  "packages": {
+    "@prisma/client": ["@prisma/client@5.1.1", "", { "dependencies": { "@prisma/engines-version": "5.1.1-1.6a3747c37ff169c90047725a05a6ef02e32ac97e" }, "peerDependencies": { "prisma": "*" }, "optionalPeers": ["prisma"] }, "sha512-fxcCeK5pMQGcgCqCrWsi+I2rpIbk0rAhdrN+ke7f34tIrgPwA68ensrpin+9+fZvuV2OtzHmuipwduSY6HswdA=="],
+
+    "@prisma/debug": ["@prisma/debug@6.3.0", "", {}, "sha512-m1lQv//0Rc5RG8TBpNUuLCxC35Ghi5XfpPmL83Gh04/GICHD2J5H2ndMlaljrUNaQDF9dOxIuFAYP1rE9wkXkg=="],
+
+    "@prisma/engines": ["@prisma/engines@6.3.0", "", { "dependencies": { "@prisma/debug": "6.3.0", "@prisma/engines-version": "6.3.0-17.acc0b9dd43eb689cbd20c9470515d719db10d0b0", "@prisma/fetch-engine": "6.3.0", "@prisma/get-platform": "6.3.0" } }, "sha512-RXqYhlZb9sx/xkUfYIZuEPn7sT0WgTxNOuEYQ7AGw3IMpP9QGVEDVsluc/GcNkM8NTJszeqk8AplJzI9lm7Jxw=="],
+
+    "@prisma/engines-version": ["@prisma/engines-version@5.1.1-1.6a3747c37ff169c90047725a05a6ef02e32ac97e", "", {}, "sha512-owZqbY/wucbr65bXJ/ljrHPgQU5xXTSkmcE/JcbqE1kusuAXV/TLN3/exmz21SZ5rJ7WDkyk70J2G/n68iogbQ=="],
+
+    "@prisma/fetch-engine": ["@prisma/fetch-engine@6.3.0", "", { "dependencies": { "@prisma/debug": "6.3.0", "@prisma/engines-version": "6.3.0-17.acc0b9dd43eb689cbd20c9470515d719db10d0b0", "@prisma/get-platform": "6.3.0" } }, "sha512-GBy0iT4f1mH31ePzfcpVSUa7JLRTeq4914FG2vR3LqDwRweSm4ja1o5flGDz+eVIa/BNYfkBvRRxv4D6ve6Eew=="],
+
+    "@prisma/get-platform": ["@prisma/get-platform@6.3.0", "", { "dependencies": { "@prisma/debug": "6.3.0" } }, "sha512-V8zZ1d0xfyi6FjpNP4AcYuwSpGcdmu35OXWnTPm8IW594PYALzKXHwIa9+o0f+Lo9AecFWrwrwaoYe56UNfTtQ=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "prisma": ["prisma@6.3.0", "", { "dependencies": { "@prisma/engines": "6.3.0" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "typescript": ">=5.1.0" }, "optionalPeers": ["typescript"], "bin": { "prisma": "build/index.js" } }, "sha512-y+Zh3Qg+xGCWyyrNUUNaFW/OltaV/yXYuTa0WRgYkz5LGyifmAsgpv94I47+qGRocZrMGcbF2A/78/oO2zgifA=="],
+
+    "@prisma/engines/@prisma/engines-version": ["@prisma/engines-version@6.3.0-17.acc0b9dd43eb689cbd20c9470515d719db10d0b0", "", {}, "sha512-R/ZcMuaWZT2UBmgX3Ko6PAV3f8//ZzsjRIG1eKqp3f2rqEqVtCv+mtzuH2rBPUC9ujJ5kCb9wwpxeyCkLcHVyA=="],
+
+    "@prisma/fetch-engine/@prisma/engines-version": ["@prisma/engines-version@6.3.0-17.acc0b9dd43eb689cbd20c9470515d719db10d0b0", "", {}, "sha512-R/ZcMuaWZT2UBmgX3Ko6PAV3f8//ZzsjRIG1eKqp3f2rqEqVtCv+mtzuH2rBPUC9ujJ5kCb9wwpxeyCkLcHVyA=="],
+  }
+}

--- a/bun/bun.lock
+++ b/bun/bun.lock
@@ -7,29 +7,17 @@
         "@prisma/client": "5.1.1",
       },
       "devDependencies": {
-        "prisma": "^6.3.0",
+        "prisma": "5.1.1",
       },
     },
   },
   "packages": {
     "@prisma/client": ["@prisma/client@5.1.1", "", { "dependencies": { "@prisma/engines-version": "5.1.1-1.6a3747c37ff169c90047725a05a6ef02e32ac97e" }, "peerDependencies": { "prisma": "*" }, "optionalPeers": ["prisma"] }, "sha512-fxcCeK5pMQGcgCqCrWsi+I2rpIbk0rAhdrN+ke7f34tIrgPwA68ensrpin+9+fZvuV2OtzHmuipwduSY6HswdA=="],
 
-    "@prisma/debug": ["@prisma/debug@6.3.0", "", {}, "sha512-m1lQv//0Rc5RG8TBpNUuLCxC35Ghi5XfpPmL83Gh04/GICHD2J5H2ndMlaljrUNaQDF9dOxIuFAYP1rE9wkXkg=="],
-
-    "@prisma/engines": ["@prisma/engines@6.3.0", "", { "dependencies": { "@prisma/debug": "6.3.0", "@prisma/engines-version": "6.3.0-17.acc0b9dd43eb689cbd20c9470515d719db10d0b0", "@prisma/fetch-engine": "6.3.0", "@prisma/get-platform": "6.3.0" } }, "sha512-RXqYhlZb9sx/xkUfYIZuEPn7sT0WgTxNOuEYQ7AGw3IMpP9QGVEDVsluc/GcNkM8NTJszeqk8AplJzI9lm7Jxw=="],
+    "@prisma/engines": ["@prisma/engines@5.1.1", "", {}, "sha512-NV/4nVNWFZSJCCIA3HIFJbbDKO/NARc9ej0tX5S9k2EVbkrFJC4Xt9b0u4rNZWL4V+F5LAjvta8vzEUw0rw+HA=="],
 
     "@prisma/engines-version": ["@prisma/engines-version@5.1.1-1.6a3747c37ff169c90047725a05a6ef02e32ac97e", "", {}, "sha512-owZqbY/wucbr65bXJ/ljrHPgQU5xXTSkmcE/JcbqE1kusuAXV/TLN3/exmz21SZ5rJ7WDkyk70J2G/n68iogbQ=="],
 
-    "@prisma/fetch-engine": ["@prisma/fetch-engine@6.3.0", "", { "dependencies": { "@prisma/debug": "6.3.0", "@prisma/engines-version": "6.3.0-17.acc0b9dd43eb689cbd20c9470515d719db10d0b0", "@prisma/get-platform": "6.3.0" } }, "sha512-GBy0iT4f1mH31ePzfcpVSUa7JLRTeq4914FG2vR3LqDwRweSm4ja1o5flGDz+eVIa/BNYfkBvRRxv4D6ve6Eew=="],
-
-    "@prisma/get-platform": ["@prisma/get-platform@6.3.0", "", { "dependencies": { "@prisma/debug": "6.3.0" } }, "sha512-V8zZ1d0xfyi6FjpNP4AcYuwSpGcdmu35OXWnTPm8IW594PYALzKXHwIa9+o0f+Lo9AecFWrwrwaoYe56UNfTtQ=="],
-
-    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
-
-    "prisma": ["prisma@6.3.0", "", { "dependencies": { "@prisma/engines": "6.3.0" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "typescript": ">=5.1.0" }, "optionalPeers": ["typescript"], "bin": { "prisma": "build/index.js" } }, "sha512-y+Zh3Qg+xGCWyyrNUUNaFW/OltaV/yXYuTa0WRgYkz5LGyifmAsgpv94I47+qGRocZrMGcbF2A/78/oO2zgifA=="],
-
-    "@prisma/engines/@prisma/engines-version": ["@prisma/engines-version@6.3.0-17.acc0b9dd43eb689cbd20c9470515d719db10d0b0", "", {}, "sha512-R/ZcMuaWZT2UBmgX3Ko6PAV3f8//ZzsjRIG1eKqp3f2rqEqVtCv+mtzuH2rBPUC9ujJ5kCb9wwpxeyCkLcHVyA=="],
-
-    "@prisma/fetch-engine/@prisma/engines-version": ["@prisma/engines-version@6.3.0-17.acc0b9dd43eb689cbd20c9470515d719db10d0b0", "", {}, "sha512-R/ZcMuaWZT2UBmgX3Ko6PAV3f8//ZzsjRIG1eKqp3f2rqEqVtCv+mtzuH2rBPUC9ujJ5kCb9wwpxeyCkLcHVyA=="],
+    "prisma": ["prisma@5.1.1", "", { "dependencies": { "@prisma/engines": "5.1.1" }, "bin": { "prisma": "build/index.js" } }, "sha512-WJFG/U7sMmcc6TjJTTifTfpI6Wjoh55xl4AzopVwAdyK68L9/ogNo8QQ2cxuUjJf/Wa82z/uhyh3wMzvRIBphg=="],
   }
 }

--- a/bun/package.json
+++ b/bun/package.json
@@ -5,6 +5,6 @@
     "@prisma/client": "5.1.1"
   },
   "devDependencies": {
-    "prisma": "^6.3.0"
+    "prisma": "5.1.1"
   }
 }

--- a/bun/package.json
+++ b/bun/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "bun",
+  "type": "module",
+  "dependencies": {
+    "@prisma/client": "5.1.1"
+  },
+  "devDependencies": {
+    "prisma": "^6.3.0"
+  }
+}

--- a/bun/prisma/schema.prisma
+++ b/bun/prisma/schema.prisma
@@ -1,0 +1,17 @@
+// This is your Prisma schema file,
+// learn more about it in the docs: https://pris.ly/d/prisma-schema
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id    Int     @id @default(autoincrement())
+  email String  @unique
+  name  String?
+}

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "pkgs": {
       "locked": {
-        "lastModified": 1718870667,
-        "narHash": "sha256-jab3Kpc8O1z3qxwVsCMHL4+18n5Wy/HHKyu1fcsF7gs=",
+        "lastModified": 1738172511,
+        "narHash": "sha256-v/8yB8LIy/KsySZYN6rO/f4kCEkj+fTLkzR0TaNMB+w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9b10b8f00cb5494795e5f51b39210fed4d2b0748",
+        "rev": "762a398892576efcc76fb233befbd58c2cef59e0",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,7 @@
             buildInputs = [
               nixpkgs.nodejs-18_x
               nixpkgs.pnpm
+              nixpkgs.bun
               nixpkgs.stdenv.cc.cc.lib
               prisma.package
               nixpkgs.nixfmt-rfc-style

--- a/readme.md
+++ b/readme.md
@@ -76,6 +76,34 @@ With nix-prisma-utils it's the other way around. You can simply install prisma t
 
 ```
 
+### Using `bun`
+
+```nix
+{
+  inputs.pkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  inputs.prisma-utils.url = "github:VanCoding/nix-prisma-utils";
+
+  outputs =
+    { pkgs, prisma-utils, ... }:
+    let
+      nixpkgs = import pkgs { system = "x86_64-linux"; };
+      prisma =
+        (prisma-utils.lib.prisma-factory {
+          inherit nixpkgs;
+          prisma-fmt-hash = "sha256-4zsJv0PW8FkGfiiv/9g0y5xWNjmRWD8Q2l2blSSBY3s="; # just copy these hashes for now, and then change them when nix complains about the mismatch
+          query-engine-hash = "sha256-6ILWB6ZmK4ac6SgAtqCkZKHbQANmcqpWO92U8CfkFzw=";
+          libquery-engine-hash = "sha256-n9IimBruqpDJStlEbCJ8nsk8L9dDW95ug+gz9DHS1Lc=";
+          schema-engine-hash = "sha256-j38xSXOBwAjIdIpbSTkFJijby6OGWCoAx+xZyms/34Q=";
+        }).fromBunLock
+          ./bun.lock; # <--- path to our bun.lock file that contains the version of prisma-engines.
+          # NOTE: does not work with bun.lockb!
+    in
+    {
+      devShells.x86_64-linux.default = nixpkgs.mkShell { shellHook = prisma.shellHook; };
+    };
+}
+```
+
 ## Testing
 
 `nix run .#test-all`

--- a/tests.nix
+++ b/tests.nix
@@ -53,18 +53,37 @@ let
         ./node_modules/.bin/prisma generate
       '';
     };
+  test-bun =
+    let
+      prisma =
+        (prisma-factory ({ inherit nixpkgs; } // hashesBySystem.${nixpkgs.system})).fromBunLock
+          ./bun/bun.lock;
+    in
+    writeShellApplication {
+      name = "test-bun";
+      runtimeInputs = [ nixpkgs.bun ];
+      text = ''
+        echo "testing bun"
+        ${prisma.shellHook}
+        cd bun
+        bun install
+        bunx prisma generate
+      '';
+    };
   test-all = writeShellApplication {
     name = "test";
     runtimeInputs = [
-      test-pnpm
       test-npm
+      test-pnpm
+      test-bun
     ];
     text = ''
       test-npm
       test-pnpm
+      test-bun
     '';
   };
 in
 {
-  inherit test-npm test-pnpm test-all;
+  inherit test-npm test-pnpm test-bun test-all;
 }

--- a/tests.nix
+++ b/tests.nix
@@ -85,5 +85,10 @@ let
   };
 in
 {
-  inherit test-npm test-pnpm test-bun test-all;
+  inherit
+    test-npm
+    test-pnpm
+    test-bun
+    test-all
+    ;
 }


### PR DESCRIPTION
closes #9 .

- [x] Write test suite for bun
- [x] All tests pass.
- [x] Format using nixfmt-rfc-style
---
I updated flake s.t. it can install bun >= 1.2.
sorry for cluttering the diff, it wasn't formatted with nixfmt-rfc-style.