### PR TITLE
Allow building prisma-engines from source via nixpkgs derivation

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1738703096,
-        "narHash": "sha256-1MABVDwNpAUrUDvyM6PlHlAB1eTWAX0eNYCzdsZ54NI=",
+        "lastModified": 1766747458,
+        "narHash": "sha256-m63jjuo/ygo8ztkCziYh5OOIbTSXUDkKbqw3Vuqu4a4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f7384aacd0ecd28681a99269ac0dff2c3a805d63",
+        "rev": "c633f572eded8c4f3c75b8010129854ed404a6ce",
         "type": "github"
       },
       "original": {
@@ -38,7 +38,28 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay",
         "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1766717007,
+        "narHash": "sha256-ZjLiHCHgoH2maP5ZAKn0anrHymbjGOS5/PZqfJUK8Ik=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "a18efe8a9112175e43397cf870fb6bc1ca480548",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     },
     "systems": {
@@ -63,11 +84,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738070913,
-        "narHash": "sha256-j6jC12vCFsTGDmY2u1H12lMr62fnclNjuCtAdF1a4Nk=",
+        "lastModified": 1766000401,
+        "narHash": "sha256-+cqN4PJz9y0JQXfAK5J1drd0U05D5fcAGhzhfVrDlsI=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "bebf27d00f7d10ba75332a0541ac43676985dea3",
+        "rev": "42d96e75aa56a3f70cab7e7dc4a32868db28e8fd",
         "type": "github"
       },
       "original": {

--- a/lib/env.nix
+++ b/lib/env.nix
@@ -1,0 +1,17 @@
+{ lib, componentsToFetch, ... }:
+
+{
+  toExportStyle =
+    attrset:
+    "\n"
+    + (lib.concatMapAttrsStringSep "\n" (name: value: "export ${name}=\"${value}\"") attrset)
+    + "\n";
+  mkEnv =
+    package:
+    builtins.listToAttrs (
+      builtins.map (c: {
+        name = c.variable;
+        value = "${package}/${c.path}";
+      }) componentsToFetch
+    );
+}

--- a/lib/legacyFetcher.nix
+++ b/lib/legacyFetcher.nix
@@ -89,7 +89,8 @@ rec {
       zlib
       openssl
       stdenv.cc.cc.lib
-    ] ++ lib.optionals (!isDarwin) [ autoPatchelfHook ];
+    ]
+    ++ lib.optionals (!isDarwin) [ autoPatchelfHook ];
     phases = [
       "buildPhase"
       "postFixupHooks"

--- a/lib/prismaFromPkgs.nix
+++ b/lib/prismaFromPkgs.nix
@@ -2,7 +2,8 @@
   lib,
   callPackage,
   fetchFromGitHub,
-  prisma-engines,
+  prisma-engines_6,
+  prisma-engines_7,
   rust-bin,
   makeRustPlatform,
   # variables
@@ -20,7 +21,16 @@ let
   };
   inherit (envFuncs) toExportStyle mkEnv;
 
-  package = prisma-engines.overrideAttrs (
+  pkgsPrismaEngines =
+    if version.majorVersion == 6 then
+      prisma-engines_6
+    else if version.majorVersion == 7 then
+      prisma-engines_7
+    else
+      throw "Version ${version.majorVersion} of prisma-engines is not supported,"
+      + " only 6 and 7 are supported.";
+
+  package = pkgsPrismaEngines.overrideAttrs (
     finalAttrs: oldAttrs:
     let
       rustToolchainPath = finalAttrs.src + "/rust-toolchain.toml";

--- a/lib/prismaFromPkgs.nix
+++ b/lib/prismaFromPkgs.nix
@@ -3,7 +3,6 @@
   callPackage,
   fetchFromGitHub,
   prisma-engines_6,
-  prisma-engines_7,
   rust-bin,
   makeRustPlatform,
   # variables
@@ -24,11 +23,10 @@ let
   pkgsPrismaEngines =
     if version.majorVersion == 6 then
       prisma-engines_6
-    else if version.majorVersion == 7 then
-      prisma-engines_7
     else
-      throw "Version ${version.majorVersion} of prisma-engines is not supported,"
-      + " only 6 and 7 are supported.";
+      throw "Version ${toString version.majorVersion} of prisma-engines is not supported,"
+      + " only version 6 is supported at the moment when building from source"
+      + " using nixpkgs.";
 
   package = pkgsPrismaEngines.overrideAttrs (
     finalAttrs: oldAttrs:

--- a/lib/prismaFromPkgs.nix
+++ b/lib/prismaFromPkgs.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  callPackage,
+  fetchFromGitHub,
+  prisma-engines,
+  rust-bin,
+  makeRustPlatform,
+  # variables
+  version,
+  binaryTarget,
+  prismaEnginesGitHubHash,
+  prismaEnginesCargoHash,
+}:
+
+let
+  componentsToFetch = (callPackage ./components.nix { }).fromVersion version;
+  isDarwin = lib.strings.hasPrefix "darwin" binaryTarget;
+  envFuncs = callPackage ./env.nix {
+    inherit componentsToFetch;
+  };
+  inherit (envFuncs) toExportStyle mkEnv;
+
+  package = prisma-engines.overrideAttrs (
+    finalAttrs: oldAttrs:
+    let
+      rustToolchainPath = finalAttrs.src + "/rust-toolchain.toml";
+      rust-toolchain =
+        if builtins.pathExists rustToolchainPath then
+          rust-bin.fromRustupToolchainFile rustToolchainPath
+        else
+          rust-bin.stable.latest.default;
+      rustPlatform = makeRustPlatform {
+        rustc = rust-toolchain;
+        cargo = rust-toolchain;
+      };
+      _version = version; # avoid name clash
+    in
+    rec {
+      src = fetchFromGitHub {
+        owner = "prisma";
+        repo = "prisma-engines";
+        rev = _version.commit;
+        hash = prismaEnginesGitHubHash;
+      };
+      pname = "prisma-engines_${toString _version.majorVersion}";
+      version = _version.commit;
+
+      cargoDeps = rustPlatform.fetchCargoVendor {
+        inherit src;
+        hash = prismaEnginesCargoHash;
+      };
+    }
+  );
+  env = mkEnv package;
+in
+rec {
+  inherit package env;
+  shellHook = toExportStyle env;
+}

--- a/pnpm-prisma-6/.gitignore
+++ b/pnpm-prisma-6/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+# Keep environment variables out of version control
+.env

--- a/pnpm-prisma-6/package.json
+++ b/pnpm-prisma-6/package.json
@@ -11,6 +11,6 @@
   "license": "ISC",
   "dependencies": {
     "@prisma/client": "6.18.0",
-    "prisma": "^6.18.0"
+    "prisma": "6.18.0"
   }
 }

--- a/pnpm-prisma-6/package.json
+++ b/pnpm-prisma-6/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "pnpm_prisma_6",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@prisma/client": "6.18.0",
+    "prisma": "^6.18.0"
+  }
+}

--- a/pnpm-prisma-6/pnpm-lock.yaml
+++ b/pnpm-prisma-6/pnpm-lock.yaml
@@ -1,0 +1,290 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@prisma/client':
+        specifier: 6.18.0
+        version: 6.18.0(prisma@6.19.1)
+      prisma:
+        specifier: ^6.18.0
+        version: 6.19.1
+
+packages:
+
+  '@prisma/client@6.18.0':
+    resolution: {integrity: sha512-jnL2I9gDnPnw4A+4h5SuNn8Gc+1mL1Z79U/3I9eE2gbxJG1oSA+62ByPW4xkeDgwE0fqMzzpAZ7IHxYnLZ4iQA==}
+    engines: {node: '>=18.18'}
+    peerDependencies:
+      prisma: '*'
+      typescript: '>=5.1.0'
+    peerDependenciesMeta:
+      prisma:
+        optional: true
+      typescript:
+        optional: true
+
+  '@prisma/config@6.19.1':
+    resolution: {integrity: sha512-bUL/aYkGXLwxVGhJmQMtslLT7KPEfUqmRa919fKI4wQFX4bIFUKiY8Jmio/2waAjjPYrtuDHa7EsNCnJTXxiOw==}
+
+  '@prisma/debug@6.19.1':
+    resolution: {integrity: sha512-h1JImhlAd/s5nhY/e9qkAzausWldbeT+e4nZF7A4zjDYBF4BZmKDt4y0jK7EZapqOm1kW7V0e9agV/iFDy3fWw==}
+
+  '@prisma/engines-version@7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7':
+    resolution: {integrity: sha512-03bgb1VD5gvuumNf+7fVGBzfpJPjmqV423l/WxsWk2cNQ42JD0/SsFBPhN6z8iAvdHs07/7ei77SKu7aZfq8bA==}
+
+  '@prisma/engines@6.19.1':
+    resolution: {integrity: sha512-xy95dNJ7DiPf9IJ3oaVfX785nbFl7oNDzclUF+DIiJw6WdWCvPl0LPU0YqQLsrwv8N64uOQkH391ujo3wSo+Nw==}
+
+  '@prisma/fetch-engine@6.19.1':
+    resolution: {integrity: sha512-mmgcotdaq4VtAHO6keov3db+hqlBzQS6X7tR7dFCbvXjLVTxBYdSJFRWz+dq7F9p6dvWyy1X0v8BlfRixyQK6g==}
+
+  '@prisma/get-platform@6.19.1':
+    resolution: {integrity: sha512-zsg44QUiQAnFUyh6Fbt7c9HjMXHwFTqtrgcX7DAZmRgnkPyYT7Sh8Mn8D5PuuDYNtMOYcpLGg576MLfIORsBYw==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  c12@3.1.0:
+    resolution: {integrity: sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==}
+    peerDependencies:
+      magicast: ^0.3.5
+    peerDependenciesMeta:
+      magicast:
+        optional: true
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  citty@0.1.6:
+    resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
+
+  confbox@0.2.2:
+    resolution: {integrity: sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  deepmerge-ts@7.1.5:
+    resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
+    engines: {node: '>=16.0.0'}
+
+  defu@6.1.4:
+    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+
+  destr@2.0.5:
+    resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+  effect@3.18.4:
+    resolution: {integrity: sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==}
+
+  empathic@2.0.0:
+    resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
+    engines: {node: '>=14'}
+
+  exsolve@1.0.8:
+    resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
+
+  fast-check@3.23.2:
+    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
+    engines: {node: '>=8.0.0'}
+
+  giget@2.0.0:
+    resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
+    hasBin: true
+
+  jiti@2.6.1:
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+    hasBin: true
+
+  node-fetch-native@1.6.7:
+    resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+
+  nypm@0.6.2:
+    resolution: {integrity: sha512-7eM+hpOtrKrBDCh7Ypu2lJ9Z7PNZBdi/8AT3AX8xoCj43BBVHD0hPSTEvMtkMpfs8FCqBGhxB+uToIQimA111g==}
+    engines: {node: ^14.16.0 || >=16.10.0}
+    hasBin: true
+
+  ohash@2.0.11:
+    resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  perfect-debounce@1.0.0:
+    resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
+
+  pkg-types@2.3.0:
+    resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
+
+  prisma@6.19.1:
+    resolution: {integrity: sha512-XRfmGzh6gtkc/Vq3LqZJcS2884dQQW3UhPo6jNRoiTW95FFQkXFg8vkYEy6og+Pyv0aY7zRQ7Wn1Cvr56XjhQQ==}
+    engines: {node: '>=18.18'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.1.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  rc9@2.1.2:
+    resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  tinyexec@1.0.2:
+    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
+    engines: {node: '>=18'}
+
+snapshots:
+
+  '@prisma/client@6.18.0(prisma@6.19.1)':
+    optionalDependencies:
+      prisma: 6.19.1
+
+  '@prisma/config@6.19.1':
+    dependencies:
+      c12: 3.1.0
+      deepmerge-ts: 7.1.5
+      effect: 3.18.4
+      empathic: 2.0.0
+    transitivePeerDependencies:
+      - magicast
+
+  '@prisma/debug@6.19.1': {}
+
+  '@prisma/engines-version@7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7': {}
+
+  '@prisma/engines@6.19.1':
+    dependencies:
+      '@prisma/debug': 6.19.1
+      '@prisma/engines-version': 7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7
+      '@prisma/fetch-engine': 6.19.1
+      '@prisma/get-platform': 6.19.1
+
+  '@prisma/fetch-engine@6.19.1':
+    dependencies:
+      '@prisma/debug': 6.19.1
+      '@prisma/engines-version': 7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7
+      '@prisma/get-platform': 6.19.1
+
+  '@prisma/get-platform@6.19.1':
+    dependencies:
+      '@prisma/debug': 6.19.1
+
+  '@standard-schema/spec@1.1.0': {}
+
+  c12@3.1.0:
+    dependencies:
+      chokidar: 4.0.3
+      confbox: 0.2.2
+      defu: 6.1.4
+      dotenv: 16.6.1
+      exsolve: 1.0.8
+      giget: 2.0.0
+      jiti: 2.6.1
+      ohash: 2.0.11
+      pathe: 2.0.3
+      perfect-debounce: 1.0.0
+      pkg-types: 2.3.0
+      rc9: 2.1.2
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  citty@0.1.6:
+    dependencies:
+      consola: 3.4.2
+
+  confbox@0.2.2: {}
+
+  consola@3.4.2: {}
+
+  deepmerge-ts@7.1.5: {}
+
+  defu@6.1.4: {}
+
+  destr@2.0.5: {}
+
+  dotenv@16.6.1: {}
+
+  effect@3.18.4:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      fast-check: 3.23.2
+
+  empathic@2.0.0: {}
+
+  exsolve@1.0.8: {}
+
+  fast-check@3.23.2:
+    dependencies:
+      pure-rand: 6.1.0
+
+  giget@2.0.0:
+    dependencies:
+      citty: 0.1.6
+      consola: 3.4.2
+      defu: 6.1.4
+      node-fetch-native: 1.6.7
+      nypm: 0.6.2
+      pathe: 2.0.3
+
+  jiti@2.6.1: {}
+
+  node-fetch-native@1.6.7: {}
+
+  nypm@0.6.2:
+    dependencies:
+      citty: 0.1.6
+      consola: 3.4.2
+      pathe: 2.0.3
+      pkg-types: 2.3.0
+      tinyexec: 1.0.2
+
+  ohash@2.0.11: {}
+
+  pathe@2.0.3: {}
+
+  perfect-debounce@1.0.0: {}
+
+  pkg-types@2.3.0:
+    dependencies:
+      confbox: 0.2.2
+      exsolve: 1.0.8
+      pathe: 2.0.3
+
+  prisma@6.19.1:
+    dependencies:
+      '@prisma/config': 6.19.1
+      '@prisma/engines': 6.19.1
+    transitivePeerDependencies:
+      - magicast
+
+  pure-rand@6.1.0: {}
+
+  rc9@2.1.2:
+    dependencies:
+      defu: 6.1.4
+      destr: 2.0.5
+
+  readdirp@4.1.2: {}
+
+  tinyexec@1.0.2: {}

--- a/pnpm-prisma-6/pnpm-lock.yaml
+++ b/pnpm-prisma-6/pnpm-lock.yaml
@@ -10,10 +10,10 @@ importers:
     dependencies:
       '@prisma/client':
         specifier: 6.18.0
-        version: 6.18.0(prisma@6.19.1)
+        version: 6.18.0(prisma@6.18.0)
       prisma:
-        specifier: ^6.18.0
-        version: 6.19.1
+        specifier: 6.18.0
+        version: 6.18.0
 
 packages:
 
@@ -29,23 +29,23 @@ packages:
       typescript:
         optional: true
 
-  '@prisma/config@6.19.1':
-    resolution: {integrity: sha512-bUL/aYkGXLwxVGhJmQMtslLT7KPEfUqmRa919fKI4wQFX4bIFUKiY8Jmio/2waAjjPYrtuDHa7EsNCnJTXxiOw==}
+  '@prisma/config@6.18.0':
+    resolution: {integrity: sha512-rgFzspCpwsE+q3OF/xkp0fI2SJ3PfNe9LLMmuSVbAZ4nN66WfBiKqJKo/hLz3ysxiPQZf8h1SMf2ilqPMeWATQ==}
 
-  '@prisma/debug@6.19.1':
-    resolution: {integrity: sha512-h1JImhlAd/s5nhY/e9qkAzausWldbeT+e4nZF7A4zjDYBF4BZmKDt4y0jK7EZapqOm1kW7V0e9agV/iFDy3fWw==}
+  '@prisma/debug@6.18.0':
+    resolution: {integrity: sha512-PMVPMmxPj0ps1VY75DIrT430MoOyQx9hmm174k6cmLZpcI95rAPXOQ+pp8ANQkJtNyLVDxnxVJ0QLbrm/ViBcg==}
 
-  '@prisma/engines-version@7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7':
-    resolution: {integrity: sha512-03bgb1VD5gvuumNf+7fVGBzfpJPjmqV423l/WxsWk2cNQ42JD0/SsFBPhN6z8iAvdHs07/7ei77SKu7aZfq8bA==}
+  '@prisma/engines-version@6.18.0-8.34b5a692b7bd79939a9a2c3ef97d816e749cda2f':
+    resolution: {integrity: sha512-T7Af4QsJQnSgWN1zBbX+Cha5t4qjHRxoeoWpK4JugJzG/ipmmDMY5S+O0N1ET6sCBNVkf6lz+Y+ZNO9+wFU8pQ==}
 
-  '@prisma/engines@6.19.1':
-    resolution: {integrity: sha512-xy95dNJ7DiPf9IJ3oaVfX785nbFl7oNDzclUF+DIiJw6WdWCvPl0LPU0YqQLsrwv8N64uOQkH391ujo3wSo+Nw==}
+  '@prisma/engines@6.18.0':
+    resolution: {integrity: sha512-i5RzjGF/ex6AFgqEe2o1IW8iIxJGYVQJVRau13kHPYEL1Ck8Zvwuzamqed/1iIljs5C7L+Opiz5TzSsUebkriA==}
 
-  '@prisma/fetch-engine@6.19.1':
-    resolution: {integrity: sha512-mmgcotdaq4VtAHO6keov3db+hqlBzQS6X7tR7dFCbvXjLVTxBYdSJFRWz+dq7F9p6dvWyy1X0v8BlfRixyQK6g==}
+  '@prisma/fetch-engine@6.18.0':
+    resolution: {integrity: sha512-TdaBvTtBwP3IoqVYoGIYpD4mWlk0pJpjTJjir/xLeNWlwog7Sl3bD2J0jJ8+5+q/6RBg+acb9drsv5W6lqae7A==}
 
-  '@prisma/get-platform@6.19.1':
-    resolution: {integrity: sha512-zsg44QUiQAnFUyh6Fbt7c9HjMXHwFTqtrgcX7DAZmRgnkPyYT7Sh8Mn8D5PuuDYNtMOYcpLGg576MLfIORsBYw==}
+  '@prisma/get-platform@6.18.0':
+    resolution: {integrity: sha512-uXNJCJGhxTCXo2B25Ta91Rk1/Nmlqg9p7G9GKh8TPhxvAyXCvMNQoogj4JLEUy+3ku8g59cpyQIKFhqY2xO2bg==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -128,8 +128,8 @@ packages:
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
 
-  prisma@6.19.1:
-    resolution: {integrity: sha512-XRfmGzh6gtkc/Vq3LqZJcS2884dQQW3UhPo6jNRoiTW95FFQkXFg8vkYEy6og+Pyv0aY7zRQ7Wn1Cvr56XjhQQ==}
+  prisma@6.18.0:
+    resolution: {integrity: sha512-bXWy3vTk8mnRmT+SLyZBQoC2vtV9Z8u7OHvEu+aULYxwiop/CPiFZ+F56KsNRNf35jw+8wcu8pmLsjxpBxAO9g==}
     engines: {node: '>=18.18'}
     hasBin: true
     peerDependencies:
@@ -154,11 +154,11 @@ packages:
 
 snapshots:
 
-  '@prisma/client@6.18.0(prisma@6.19.1)':
+  '@prisma/client@6.18.0(prisma@6.18.0)':
     optionalDependencies:
-      prisma: 6.19.1
+      prisma: 6.18.0
 
-  '@prisma/config@6.19.1':
+  '@prisma/config@6.18.0':
     dependencies:
       c12: 3.1.0
       deepmerge-ts: 7.1.5
@@ -167,26 +167,26 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@prisma/debug@6.19.1': {}
+  '@prisma/debug@6.18.0': {}
 
-  '@prisma/engines-version@7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7': {}
+  '@prisma/engines-version@6.18.0-8.34b5a692b7bd79939a9a2c3ef97d816e749cda2f': {}
 
-  '@prisma/engines@6.19.1':
+  '@prisma/engines@6.18.0':
     dependencies:
-      '@prisma/debug': 6.19.1
-      '@prisma/engines-version': 7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7
-      '@prisma/fetch-engine': 6.19.1
-      '@prisma/get-platform': 6.19.1
+      '@prisma/debug': 6.18.0
+      '@prisma/engines-version': 6.18.0-8.34b5a692b7bd79939a9a2c3ef97d816e749cda2f
+      '@prisma/fetch-engine': 6.18.0
+      '@prisma/get-platform': 6.18.0
 
-  '@prisma/fetch-engine@6.19.1':
+  '@prisma/fetch-engine@6.18.0':
     dependencies:
-      '@prisma/debug': 6.19.1
-      '@prisma/engines-version': 7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7
-      '@prisma/get-platform': 6.19.1
+      '@prisma/debug': 6.18.0
+      '@prisma/engines-version': 6.18.0-8.34b5a692b7bd79939a9a2c3ef97d816e749cda2f
+      '@prisma/get-platform': 6.18.0
 
-  '@prisma/get-platform@6.19.1':
+  '@prisma/get-platform@6.18.0':
     dependencies:
-      '@prisma/debug': 6.19.1
+      '@prisma/debug': 6.18.0
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -271,10 +271,10 @@ snapshots:
       exsolve: 1.0.8
       pathe: 2.0.3
 
-  prisma@6.19.1:
+  prisma@6.18.0:
     dependencies:
-      '@prisma/config': 6.19.1
-      '@prisma/engines': 6.19.1
+      '@prisma/config': 6.18.0
+      '@prisma/engines': 6.18.0
     transitivePeerDependencies:
       - magicast
 

--- a/pnpm-prisma-6/prisma/schema.prisma
+++ b/pnpm-prisma-6/prisma/schema.prisma
@@ -1,0 +1,18 @@
+// This is your Prisma schema file,
+// learn more about it in the docs: https://pris.ly/d/prisma-schema
+
+generator client {
+    provider = "prisma-client-js"
+}
+
+datasource db {
+    provider = "sqlite"
+    url      = env("DATABASE_URL")
+}
+
+model User {
+    id        Int      @id @default(autoincrement())
+    createdAt DateTime @default(now())
+    email     String   @unique
+    name      String?
+}

--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,43 @@ With nix-prisma-utils it's the other way around. You can simply install prisma t
 }
 ```
 
+## Building prisma-engines from source
+
+In some cases, it might be desirable to build the prisma engines from source using the nixpkgs derivation instead of relying on prebuilt binaries.
+For example, this might be helpful when trying to use prisma on an architecture that is not officially supported by prisma (hence has no prebuilt binaries), but for which prisma-engines can be correctly built using the derivation in nixpkgs.
+
+Note that this requires that the version of prisma-engines specified in the lockfile can be successfully built by the upstream derivation in nixpkgs, so it is not guaranteed that this approach can be successfully used for any version of prisma-engines. Also, only the major version prisma-engines 6 is supported at the moment.
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    prisma-utils.url = "github:VanCoding/nix-prisma-utils";
+  };
+
+  outputs =
+    { nixpkgs, prisma-utils, ... }:
+    let
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+      prisma = prisma-utils.lib.prisma-factory {
+        inherit pkgs;
+        # leave the hashes empty, nix will complain and tell you the right hash
+        usePrismaFromPkgs = true;
+        prismaEnginesGitHubHash = "";
+        prismaEnginesCargoHash = "";
+        npmLock = ./package-lock.json; # <--- path to our package-lock.json file that contains the version of prisma-engines
+        # Lockfiles of other package managers are supported as well.
+      };
+    in
+    {
+      devShells.${system}.default = pkgs.mkShell {
+        env = prisma.env;
+      };
+    };
+}
+```
+
 ## Legacy API
 
 The [Legacy API](./legacy-api.md) (with fromNpmLock, fromYarnLock, etc.) is now deprecated and we recommend switching to the new API above.

--- a/tests.nix
+++ b/tests.nix
@@ -49,8 +49,8 @@ let
       let
         args = {
           usePrismaFromPkgs = true;
-          prismaEnginesGitHubHash = "sha256-z3GdnrLEMJIGPKXXbz2wrbiGpuNlgYxqg3iYINYTnPI=";
-          prismaEnginesCargoHash = "sha256-PgCfBcmK9RCA5BMacJ5oYEpo2DnBKx2xPbdLb79yCCY=";
+          prismaEnginesGitHubHash = "sha256-p198o8ON5mGPCxK+gE0mW+JVyQlNsCsqwa8D4MNBkpA=";
+          prismaEnginesCargoHash = "sha256-bNl04GoxLX+B8dPgqWL/VarreBVebjwNDwQjtQcJnsg=";
         };
       in
       {

--- a/tests.nix
+++ b/tests.nix
@@ -18,7 +18,7 @@ let
         x86_64-darwin.hash = "sha256-z1VypBp/JN4qipqTFDmVPb/H1I+TdQVcUU4EIsIPQJ8=";
         aarch64-darwin.hash = "sha256-LxpKAAjnRn8eH7h9trOOYKf0WcY+aHGrzzVGW2aViek=";
       }
-    else
+    else if fetcherMode == "legacy" then
       {
         x86_64-linux = {
           prisma-fmt-hash = "sha256-4zsJv0PW8FkGfiiv/9g0y5xWNjmRWD8Q2l2blSSBY3s=";
@@ -44,6 +44,20 @@ let
           libquery-engine-hash = "sha256-4T63O+OyoEIJ0TLKoOoil06whd+41QxiXXg+0cgpX/8=";
           schema-engine-hash = "sha256-+O4IelHbZt4X+6UWol8TpL+BBDTS5JT+0hQR7ELVmZc=";
         };
+      }
+    else
+      let
+        args = {
+          usePrismaFromPkgs = true;
+          prismaEnginesGitHubHash = "sha256-z3GdnrLEMJIGPKXXbz2wrbiGpuNlgYxqg3iYINYTnPI=";
+          prismaEnginesCargoHash = "sha256-PgCfBcmK9RCA5BMacJ5oYEpo2DnBKx2xPbdLb79yCCY=";
+        };
+      in
+      {
+        x86_64-linux = args;
+        aarch64-linux = args;
+        x86_64-darwin = args;
+        aarch64-darwin = args;
       };
   test-npm =
     let
@@ -62,14 +76,13 @@ let
         ./node_modules/.bin/prisma generate
       '';
     };
-  test-pnpm =
+  makeTestPnpm =
+    lockfilePath: suffix:
     let
-      prisma =
-        (pkgs.callPackage prisma-factory hashesBySystem.${pkgs.system}).fromPnpmLock
-          ./pnpm/pnpm-lock.yaml;
+      prisma = (pkgs.callPackage prisma-factory hashesBySystem.${pkgs.system}).fromPnpmLock lockfilePath;
     in
     writeShellApplication {
-      name = "test-pnpm";
+      name = "test-pnpm${suffix}";
       runtimeInputs = [ pnpm ];
       runtimeEnv = prisma.env;
       text = ''
@@ -79,6 +92,8 @@ let
         ./node_modules/.bin/prisma generate
       '';
     };
+  test-pnpm = makeTestPnpm ./pnpm/pnpm-lock.yaml "";
+  test-pnpm-prisma-6 = makeTestPnpm ./pnpm-prisma-6/pnpm-lock.yaml "-prisma-6";
   test-bun =
     let
       prisma = (pkgs.callPackage prisma-factory hashesBySystem.${pkgs.system}).fromBunLock ./bun/bun.lock;
@@ -129,10 +144,19 @@ let
       '';
     };
 in
-{
-  "test-npm-${fetcherMode}" = test-npm;
-  "test-pnpm-${fetcherMode}" = test-pnpm;
-  "test-bun-${fetcherMode}" = test-bun;
-  "test-yarn-v1-${fetcherMode}" = test-yarn-v1;
-  "test-yarn-berry-${fetcherMode}" = test-yarn-berry;
-}
+if fetcherMode == "fromPkgs" then
+  {
+    # Using the derivation from nixpkgs only works for versions
+    # of prisma such that the derivation correctly builds it.
+    # That is not the case of prisma 5.1.1 used in the other tests,
+    # therefore we test prisma 6 (this is described in the docs).
+    "test-pnpm-prisma-6-${fetcherMode}" = test-pnpm-prisma-6;
+  }
+else
+  {
+    "test-npm-${fetcherMode}" = test-npm;
+    "test-pnpm-${fetcherMode}" = test-pnpm;
+    "test-bun-${fetcherMode}" = test-bun;
+    "test-yarn-v1-${fetcherMode}" = test-yarn-v1;
+    "test-yarn-berry-${fetcherMode}" = test-yarn-berry;
+  }


### PR DESCRIPTION
This PR enables building `prisma-engines` from source using the Nixpkgs derivation instead of relying on prebuilt binaries. This is useful to me because I am trying to use prisma on the `armv7-linux` system, which is not officially supported by prisma (so there are no official prebuilt binaries for it), but it can be built successfully using the derivation in nixpkgs.

Building from source can be enabled by using `prisma-factory` like this:
```nix
prisma-utils.lib.prisma-factory {
    inherit pkgs;
    # leave the hashes empty, nix will complain and tell you the right hash
    usePrismaFromPkgs = true;
    prismaEnginesGitHubHash = "";
    prismaEnginesCargoHash = "";
    npmLock = ./package-lock.json;
    # Lockfiles of other package managers are supported as well.
};
```
Building from source works by using the `prisma-engines_6` package in nixpkgs and overriding the source with the specified commit from GitHub, overriding the rust toolchain with the one specified in the `rust-toolchain.toml` file in the `prisma-engines` source code, and overriding cargo dependencies with ones specified in the source code. For overriding the rust toolchain, the [oxalica/rust-overlay](https://github.com/oxalica/rust-overlay) flake is used to obtain the toolchain corresponding to the `rust-toolchain.toml` file. This is necessary because newer versions of prisma-engines might require a newer toolchain than the one present in nixpkgs.

It must be noted that because the build process might vary between various versions of prisma, this approach is not always guaranteed to work and will only work for versions of prisma that successfully build using the nixpkgs derivation. Most notably, only major version 6 of prisma-engines is supported right now, as I do not have the bandwidth right now to fully test it for prisma-engines 7 which I am myself not using at the moment (nixpkgs has `prisma-engines_7`, but it seems that it does not build all the components that are expected in `components.nix` and as is it will probably not work together with prisma 6).

Because the tests for existing fetchers use version 5.1.1 of prisma-engines, and building from source is only supported for major version 6, it is not possible to use the same for lockfiles for testing. For this reason, I include the directory `pnpm-prisma-6`, which contains a pnpm lockfile with prisma-engines 6.18.0, used to test building from source.

## Included Changes

- Added the functionality for building from source to `prismaFromPkgs.nix`
- Modified `prisma.nix` to recognize and handle `usePrismaFromPkgs = true;`
- Extracted the `toExportStyle` and `mkEnv` helper function to a separate file `env.nix`
- Added `rust-overlay` as flake input and passed `rust-bin` as an argument to `prisma-factory`
- Added the `pnpm-prisma-6` with a pnpm package depending on prisma-engines 6.18.0
- Added a test testing the prisma built from source
- Updated the flake lockfile (needed to have nixpkgs with a reasonable recent derivation of prisma-engines)
- Updated the obsolete shell package `pkgs.nodejs-18_x` with `pkgs.nodejs_24`
- Updated the readme with documentation of the feature